### PR TITLE
create log directory from ansible

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@
     -   id: check-json
     -   id: end-of-file-fixer
 -   repo: https://github.com/willthames/ansible-lint.git
-    sha: v3.4.13
+    sha: v3.4.15
     hooks:
     -   id: ansible-lint
         files: \.(yaml|yml)$

--- a/tasks/service-upstart.yml
+++ b/tasks/service-upstart.yml
@@ -1,4 +1,13 @@
 ---
+- name: create logdir
+  become: true
+  file:
+    path: "{{ postgres_exporter_log_path }}"
+    owner: "{{ postgres_exporter_user }}"
+    group: "{{ postgres_exporter_group }}"
+    state: directory
+    mode: 0750
+
 - name: upstart service
   become: true
   template:

--- a/templates/postgres_exporter.upstart.j2
+++ b/templates/postgres_exporter.upstart.j2
@@ -13,12 +13,6 @@ env logdir={{ postgres_exporter_log_path }}
 env user={{ postgres_exporter_user }}
 env group={{ postgres_exporter_group }}
 
-pre-start script
-  mkdir -p $logdir || true
-  chmod 0750 $logdir || true
-  chown $user:$group $logdir || true
-end script
-
 script
   if [ -f "{{ postgres_exporter_config_file }}" ] ; then
     . "{{ postgres_exporter_config_file }}"

--- a/templates/postgres_exporter.upstart.j2
+++ b/templates/postgres_exporter.upstart.j2
@@ -16,6 +16,7 @@ env group={{ postgres_exporter_group }}
 script
   if [ -f "{{ postgres_exporter_config_file }}" ] ; then
     . "{{ postgres_exporter_config_file }}"
+    export DATA_SOURCE_NAME
   fi
 
   pidfile={{ postgres_exporter_pid_path }}/$name.pid


### PR DESCRIPTION
This PR aims to fix the following issue encountered on some ubuntu 14.04:
mkdir: cannot create directory '/var/log/node_exporter': Permission denied

This error occurs because the pre-start script in upstart is run with postgres_exporter_user:postgres_exporter_group instead of root:root.

The fix move the log directory creation in ansible instead.

It also fixes an issue with a missing DATA_SOURCE_NAME which is not exported from the upstart script.